### PR TITLE
add doc for spare param

### DIFF
--- a/resources/docs/spare_parameters.md
+++ b/resources/docs/spare_parameters.md
@@ -1,0 +1,19 @@
+# Houdini Ramen: Spare Parameters Guidelines
+
+You can add custom spare parameters to any Houdini node using the `add_spare_*` builder methods. This is especially useful for creating control nulls (`SopNull`) to drive other parameters in a network.
+
+Available methods:
+- `add_spare_float(name, label, default_value, min, max)`
+- `add_spare_int(name, label, default_value, min, max)`
+- `add_spare_string(name, label, default_value)`
+- `add_spare_toggle(name, label, default_value)`
+
+The `name` should be a valid Houdini internal parameter name (snake_case), and the `label` is the human-readable UI text.
+
+```rust
+let ctrl_node = SopNull::new("CONTROLLER")
+    .add_spare_float("radius", "Radius", 2.5, 0.1, 10.0)
+    .add_spare_int("count", "Count", 500, 10, 1000)
+    .add_spare_string("target_path", "Target Path", "../geo1")
+    .add_spare_toggle("enable_fx", "Enable FX", true);
+```

--- a/resources/domain_graph.json
+++ b/resources/domain_graph.json
@@ -9,6 +9,11 @@
     "path": "resources/docs/operator_paths.md",
     "type": "doc"
   },
+  "doc/spare_parameters": {
+    "depends_on": [],
+    "path": "resources/docs/spare_parameters.md",
+    "type": "doc"
+  },
   "doc/vex_injection": {
     "depends_on": [],
     "path": "resources/docs/vex_injection.md",
@@ -17,6 +22,11 @@
   "sop/sopattribcopy": {
     "depends_on": [
       "doc/operator_paths"
+    ]
+  },
+  "sop/sopnull": {
+    "depends_on": [
+      "doc/spare_parameters"
     ]
   },
   "sop/sopobjectmerge": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide on spare parameter methods available for Houdini nodes
  * Documented support for `add_spare_float`, `add_spare_int`, `add_spare_string`, and `add_spare_toggle` methods with usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->