### PR TITLE
add noise sphere example and sphere documentation

### DIFF
--- a/examples/003_noise_sphere.rs
+++ b/examples/003_noise_sphere.rs
@@ -1,0 +1,72 @@
+use houdini_ramen::core::graph::NodeGraph;
+use houdini_ramen::core::live_link::send_to_houdini;
+use houdini_ramen::core::types::ContainerType::Geo;
+use houdini_ramen::core::types::{RampInterpolation, RampPoint, SpareFloat};
+use houdini_ramen::generated::sop::{
+    SopColor, SopColorColortype, SopNormal, SopPointwrangle, SopSphere, SopSphereType,
+};
+
+fn main() {
+    let mut graph = NodeGraph::new("/obj/geo1")
+        .with_auto_clear()
+        .with_auto_create(Geo);
+
+    let sphere = graph.add(
+        SopSphere::new("sphere")
+            .with_type(SopSphereType::PolygonMesh)
+            .with_rows(100)
+            .with_cols(100),
+    );
+
+    let wrangle = graph.add(
+        SopPointwrangle::new("noise_deform")
+            .set_input(&sphere)
+            .with_snippet(include_str!("vex/snippets/003_noise_sphere.vfl"))
+            .add_spare(
+                SpareFloat::new("freq", "Frequency")
+                    .with_default(2.0)
+                    .with_range(0.0, 10.0),
+            )
+            .add_spare(
+                SpareFloat::new("amp", "Amplitude")
+                    .with_default(0.5)
+                    .with_range(0.0, 2.0),
+            ),
+    );
+
+    let normal = graph.add(
+        SopNormal::new("normal")
+            .set_input(&wrangle),
+    );
+
+    let color = graph.add(
+        SopColor::new("color")
+            .set_input(&normal)
+            .with_colortype(SopColorColortype::RampFromAttribute)
+            .with_rampattribute("disp")
+            .with_ramprange([-1.0, 1.0])
+            .with_ramp(vec![
+                RampPoint {
+                    position: 0.0,
+                    value: vec![0.1, 0.2, 0.8],
+                    interpolation: RampInterpolation::Linear,
+                },
+                RampPoint {
+                    position: 0.5,
+                    value: vec![0.6, 0.1, 0.8],
+                    interpolation: RampInterpolation::Linear,
+                },
+                RampPoint {
+                    position: 1.0,
+                    value: vec![1.0, 0.4, 0.1],
+                    interpolation: RampInterpolation::Linear,
+                },
+            ]),
+    );
+
+    graph.set_display(&color);
+
+    let python_script = graph.build();
+    println!("{}", python_script);
+    send_to_houdini(&python_script);
+}

--- a/examples/vex/snippets/003_noise_sphere.vfl
+++ b/examples/vex/snippets/003_noise_sphere.vfl
@@ -1,0 +1,3 @@
+float noise_val = snoise(@P * chf("freq"));
+@P += @N * noise_val * chf("amp");
+f@disp = noise_val;

--- a/resources/docs/sop_sphere.md
+++ b/resources/docs/sop_sphere.md
@@ -1,0 +1,8 @@
+# Houdini Ramen: SopSphere Parameter Dependencies
+
+The `SopSphere` node has implicit parameter dependencies based on its `type` (Primitive Type). If you want to increase the resolution of the sphere, you MUST set the parameters according to the selected type:
+
+- For `SopSphereType::PolygonMesh`: You MUST use `.with_rows()` and `.with_cols()` to set the resolution.
+- For `SopSphereType::Polygon` (Triangles): `rows` and `cols` are ignored. You MUST use `.with_freq()` instead.
+
+If you are asked to create a high-resolution sphere for deformation, `PolygonMesh` with `rows` and `cols` is generally preferred.

--- a/resources/domain_graph.json
+++ b/resources/domain_graph.json
@@ -24,6 +24,11 @@
     "path": "resources/docs/ramp_parameters.md",
     "type": "doc"
   },
+  "doc/sop_sphere": {
+    "depends_on": [],
+    "path": "resources/docs/sop_sphere.md",
+    "type": "doc"
+  },
   "doc/spare_parameters": {
     "depends_on": [],
     "path": "resources/docs/spare_parameters.md",
@@ -52,6 +57,11 @@
   "sop/sopobjectmerge": {
     "depends_on": [
       "doc/operator_paths"
+    ]
+  },
+  "sop/sopsphere": {
+    "depends_on": [
+      "doc/sop_sphere"
     ]
   },
   "task/basic_workflow": {


### PR DESCRIPTION
This example demonstrates noise-based geometry deformation using VEX snippets, spare parameters, and attribute-based color ramps. It also adds documentation regarding SopSphere parameter dependencies for different primitive types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example demonstrating noise-based geometry deformation with color attribute mapping.

* **Documentation**
  * Added documentation for sphere node parameter configuration and usage recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->