### PR TITLE
feat: add houdini node probing and analysis tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ houdini_warnings.log
 resources/stubs/
 memo
 resources/auto_graph.json
+
+# can be deleted once the probe finished.
+probe_io_report.json
+vop_context_mapping.json

--- a/Justfile
+++ b/Justfile
@@ -103,3 +103,9 @@ ramp-value: (_hython "tools/probe/ramp_interpolation_value.py")
 
 list-types:
     uv run python tools/probe/list_types.py
+
+explore-out-label: (_hython "tools/probe/explore_out_label.py")
+explore-out-label2: (_hython "tools/probe/explore_out_label2.py")
+analyze-vop-failure: (_hython "tools/probe/analyze_vop_failures.py")
+probe_vop_contexts: (_hython "tools/probe/probe_vop_contexts.py")
+analyze-failure: (_hython "tools/probe/analyze_other_failures.py")

--- a/examples/004_dynamics.rs
+++ b/examples/004_dynamics.rs
@@ -6,7 +6,9 @@ use houdini_ramen::sop::{
     SopAttribvop, SopAttribvopBindclass, SopAttribvopInnerExt, SopScatter, SopSolver,
     SopSolverInnerExt, SopTestgeometryRubbertoy,
 };
-use houdini_ramen_vop::{VopAdd, VopGeometryvopglobal, VopGeometryvopglobalOutputs};
+use houdini_ramen_vop::{
+    VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopMultiply,
+};
 
 fn main() {
     let mut graph = NodeGraph::new("/obj/geo1")
@@ -37,7 +39,18 @@ fn main() {
                 .typed_as::<VopGeometryvopglobal>();
             let out1 = vop_graph.geometryvopoutput1();
 
-            let add1 = vop_graph.add(VopAdd::new("add1").set_input(in1.out_p()));
+            let const1 = vop_graph.add(VopConstant::new("const1").with_floatdef(1.0 / 24.0));
+            let multiply1 = vop_graph.add(
+                VopMultiply::new("multiply1")
+                    .set_input(in1.out_v())
+                    .set_input_at(1, &const1),
+            );
+
+            let add1 = vop_graph.add(
+                VopAdd::new("add1")
+                    .set_input(in1.out_p())
+                    .set_input_at(1, &multiply1),
+            );
 
             vop_graph.connect_existing(&out1, 0, &add1);
         });

--- a/examples/004_dynamics.rs
+++ b/examples/004_dynamics.rs
@@ -10,6 +10,8 @@ use houdini_ramen_vop::{
     VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopMultiply,
 };
 
+const TIMESTEP: f32 = 1.0_f32 / 24.0_f32;
+
 fn main() {
     let mut graph = NodeGraph::new("/obj/geo1")
         .with_auto_clear()
@@ -39,7 +41,7 @@ fn main() {
                 .typed_as::<VopGeometryvopglobal>();
             let out1 = vop_graph.geometryvopoutput1();
 
-            let const1 = vop_graph.add(VopConstant::new("const1").with_floatdef(1.0 / 24.0));
+            let const1 = vop_graph.add(VopConstant::new("timestep").with_floatdef(TIMESTEP));
             let multiply1 = vop_graph.add(
                 VopMultiply::new("multiply1")
                     .set_input(in1.out_v())

--- a/tools/probe/analyze_other_failures.py
+++ b/tools/probe/analyze_other_failures.py
@@ -1,0 +1,43 @@
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def analyze_other_failures():
+    report_path = Path("probe_io_report.json")
+    if not report_path.exists():
+        print(f"File not found: {report_path}")
+        return
+
+    with open(report_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    failures = data.get("failures_instantiation", {})
+
+    target_categories = [
+        "Cop",
+        "Shop",
+        "Data",
+        "VopNet",
+        "CopNet",
+        "ChopNet",
+        "TopNet",
+        "Sop",
+    ]
+
+    for cat in target_categories:
+        cat_failures = failures.get(cat, [])
+        if not cat_failures:
+            continue
+
+        print(f"\n=== {cat} Instantiation Failures: {len(cat_failures)} total ===")
+        reasons = Counter([item.get("reason", "Unknown") for item in cat_failures])
+        for reason, count in reasons.most_common():
+            print(f"{count:>5} times: {reason}")
+
+        samples = [item.get("node") for item in cat_failures]
+        print(f"Samples: {', '.join(samples[:15])}{'...' if len(samples) > 15 else ''}")
+
+
+if __name__ == "__main__":
+    analyze_other_failures()

--- a/tools/probe/analyze_other_failures.py
+++ b/tools/probe/analyze_other_failures.py
@@ -14,19 +14,8 @@ def analyze_other_failures():
 
     failures = data.get("failures_instantiation", {})
 
-    target_categories = [
-        "Cop",
-        "Shop",
-        "Data",
-        "VopNet",
-        "CopNet",
-        "ChopNet",
-        "TopNet",
-        "Sop",
-    ]
-
-    for cat in target_categories:
-        cat_failures = failures.get(cat, [])
+    for cat in sorted(failures.keys()):
+        cat_failures = failures[cat]
         if not cat_failures:
             continue
 

--- a/tools/probe/analyze_vop_failures.py
+++ b/tools/probe/analyze_vop_failures.py
@@ -1,0 +1,37 @@
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def analyze_failures():
+    report_path = Path("probe_io_report.json")
+    if not report_path.exists():
+        print(f"File not found: {report_path}")
+        return
+
+    with open(report_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    vop_failures = data.get("failures_instantiation", {}).get("Vop", [])
+
+    if not vop_failures:
+        print("No VOP failures found in the report.")
+        return
+
+    reasons = Counter([item.get("reason", "Unknown") for item in vop_failures])
+
+    print(f"=== VOP Instantiation Failures: {len(vop_failures)} total ===")
+    for reason, count in reasons.most_common():
+        print(f"{count:>5} times: {reason}")
+
+    print("\n=== Sample nodes for 'Invalid node type name' ===")
+    samples = [
+        item.get("node")
+        for item in vop_failures
+        if "Invalid node type name" in item.get("reason", "")
+    ]
+    print(", ".join(samples[:20]) + ("..." if len(samples) > 20 else ""))
+
+
+if __name__ == "__main__":
+    analyze_failures()

--- a/tools/probe/explore_out_label.py
+++ b/tools/probe/explore_out_label.py
@@ -1,0 +1,43 @@
+import hou
+
+
+def probe_outputs():
+    obj = hou.node("/obj")
+    geo = obj.createNode("geo", "temp_geo_for_probe", run_init_scripts=False)
+
+    try:
+        attribvop = geo.createNode("attribvop", run_init_scripts=True)
+
+        test_nodes = {
+            "geometryvopglobal1": attribvop.node("geometryvopglobal1"),
+            "add1": attribvop.createNode("add"),
+            "bind1": attribvop.createNode("bind"),
+        }
+
+        for name, node in test_nodes.items():
+            if not node:
+                continue
+
+            print(f"\n=== {node.type().name()} ===")
+
+            if hasattr(node, "outputLabels"):
+                print(f"outputLabels: {node.outputLabels()}")
+
+            if hasattr(node, "outputNames"):
+                print(f"outputNames: {node.outputNames()}")
+
+            if hasattr(node, "outputDataTypes"):
+                print(f"outputDataTypes: {node.outputDataTypes()}")
+
+            output_methods = [m for m in dir(node) if "output" in m.lower()]
+            print(f"output_methods: {output_methods}")
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+    finally:
+        geo.destroy()
+
+
+if __name__ == "__main__":
+    probe_outputs()

--- a/tools/probe/explore_out_label2.py
+++ b/tools/probe/explore_out_label2.py
@@ -1,0 +1,149 @@
+import json
+import logging
+from pathlib import Path
+import hou
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+class TempNodeManager:
+    def __init__(self):
+        self.parents = {}
+        self._strategies = {
+            "Sop": ("/obj", "geo", "temp_sop_parent"),
+            "Chop": ("/ch", "ch", "temp_chop_parent"),
+            "Cop2": ("/img", "img", "temp_cop_parent"),
+            "Dop": ("/obj", "dopnet", "temp_dop_parent"),
+            "Top": ("/tasks", "topnet", "temp_top_parent"),
+            "Vop": ("/obj", "vopnet", "temp_vop_parent"),
+            "Object": (None, None, "/obj"),
+            "Lop": (None, None, "/stage"),
+            "Driver": (None, None, "/out"),
+            "Shop": ("/shop", "shop", "temp_shop_parent"),
+        }
+
+    def get_parent(self, cat_name: str):
+        if cat_name in self.parents:
+            return self.parents[cat_name]
+
+        parent = None
+        try:
+            if cat_name in self._strategies:
+                root_path, node_type, target_path = self._strategies[cat_name]
+                if node_type:
+                    root = hou.node(root_path)
+                    if root:
+                        parent = root.createNode(
+                            node_type, target_path, run_init_scripts=False
+                        )
+                else:
+                    parent = hou.node(target_path)
+        except Exception as e:
+            logger.debug(f"Failed to create temp parent for '{cat_name}': {e}")
+
+        self.parents[cat_name] = parent
+        return parent
+
+    def cleanup(self):
+        for cat_name, node in self.parents.items():
+            if node and cat_name in self._strategies and self._strategies[cat_name][1]:
+                try:
+                    node.destroy()
+                except Exception:
+                    pass
+        self.parents.clear()
+
+
+def probe_all_nodes():
+    manager = TempNodeManager()
+    report = {
+        "summary": {},
+        "failures_instantiation": {},
+        "failures_io_read": {},
+        "success_samples": {},
+    }
+
+    try:
+        categories = hou.nodeTypeCategories()
+        for cat_name, cat in sorted(categories.items()):
+            logger.info(f"Probing category: {cat_name}")
+            parent = manager.get_parent(cat_name)
+
+            cat_stats = {
+                "total": len(cat.nodeTypes()),
+                "success": 0,
+                "instantiation_failed": 0,
+                "io_read_failed": 0,
+            }
+
+            report["failures_instantiation"][cat_name] = []
+            report["failures_io_read"][cat_name] = []
+
+            for node_type_name, node_type in cat.nodeTypes().items():
+                if not parent:
+                    cat_stats["instantiation_failed"] += 1
+                    report["failures_instantiation"][cat_name].append(
+                        {
+                            "node": node_type_name,
+                            "reason": "No parent context available",
+                        }
+                    )
+                    continue
+
+                temp_node = None
+                try:
+                    temp_node = parent.createNode(
+                        node_type_name, run_init_scripts=False
+                    )
+
+                    out_labels = (
+                        temp_node.outputLabels()
+                        if hasattr(temp_node, "outputLabels")
+                        else ()
+                    )
+                    out_names = (
+                        temp_node.outputNames()
+                        if hasattr(temp_node, "outputNames")
+                        else ()
+                    )
+
+                    cat_stats["success"] += 1
+
+                    if cat_name not in report["success_samples"]:
+                        report["success_samples"][cat_name] = {
+                            "node": node_type_name,
+                            "outputLabels": list(out_labels),
+                            "outputNames": list(out_names),
+                        }
+
+                except hou.OperationFailed as e:
+                    cat_stats["instantiation_failed"] += 1
+                    report["failures_instantiation"][cat_name].append(
+                        {"node": node_type_name, "reason": str(e)}
+                    )
+                except Exception as e:
+                    cat_stats["io_read_failed"] += 1
+                    report["failures_io_read"][cat_name].append(
+                        {"node": node_type_name, "reason": str(e)}
+                    )
+                finally:
+                    if temp_node:
+                        try:
+                            temp_node.destroy()
+                        except Exception:
+                            pass
+
+            report["summary"][cat_name] = cat_stats
+
+    finally:
+        manager.cleanup()
+
+    out_path = Path("probe_io_report.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+    logger.info(f"Probe completed. Report saved to {out_path.absolute()}")
+
+
+if __name__ == "__main__":
+    probe_all_nodes()

--- a/tools/probe/explore_out_label2.py
+++ b/tools/probe/explore_out_label2.py
@@ -96,7 +96,14 @@ def probe_all_nodes():
                     temp_node = parent.createNode(
                         node_type_name, run_init_scripts=False
                     )
+                except hou.OperationFailed as e:
+                    cat_stats["instantiation_failed"] += 1
+                    report["failures_instantiation"][cat_name].append(
+                        {"node": node_type_name, "reason": str(e)}
+                    )
+                    continue
 
+                try:
                     out_labels = (
                         temp_node.outputLabels()
                         if hasattr(temp_node, "outputLabels")
@@ -117,22 +124,16 @@ def probe_all_nodes():
                             "outputNames": list(out_names),
                         }
 
-                except hou.OperationFailed as e:
-                    cat_stats["instantiation_failed"] += 1
-                    report["failures_instantiation"][cat_name].append(
-                        {"node": node_type_name, "reason": str(e)}
-                    )
                 except Exception as e:
                     cat_stats["io_read_failed"] += 1
                     report["failures_io_read"][cat_name].append(
                         {"node": node_type_name, "reason": str(e)}
                     )
                 finally:
-                    if temp_node:
-                        try:
-                            temp_node.destroy()
-                        except Exception:
-                            pass
+                    try:
+                        temp_node.destroy()
+                    except Exception:
+                        pass
 
             report["summary"][cat_name] = cat_stats
 

--- a/tools/probe/explore_out_label2.py
+++ b/tools/probe/explore_out_label2.py
@@ -50,8 +50,10 @@ class TempNodeManager:
             if node and cat_name in self._strategies and self._strategies[cat_name][1]:
                 try:
                     node.destroy()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(
+                        f"Failed to destroy temp parent for '{cat_name}': {e}"
+                    )
         self.parents.clear()
 
 
@@ -80,7 +82,7 @@ def probe_all_nodes():
             report["failures_instantiation"][cat_name] = []
             report["failures_io_read"][cat_name] = []
 
-            for node_type_name, node_type in cat.nodeTypes().items():
+            for node_type_name, _node_type in cat.nodeTypes().items():
                 if not parent:
                     cat_stats["instantiation_failed"] += 1
                     report["failures_instantiation"][cat_name].append(
@@ -96,7 +98,7 @@ def probe_all_nodes():
                     temp_node = parent.createNode(
                         node_type_name, run_init_scripts=False
                     )
-                except hou.OperationFailed as e:
+                except Exception as e:
                     cat_stats["instantiation_failed"] += 1
                     report["failures_instantiation"][cat_name].append(
                         {"node": node_type_name, "reason": str(e)}
@@ -132,8 +134,10 @@ def probe_all_nodes():
                 finally:
                     try:
                         temp_node.destroy()
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(
+                            f"Failed to destroy temp node '{node_type_name}' in '{cat_name}': {e}"
+                        )
 
             report["summary"][cat_name] = cat_stats
 

--- a/tools/probe/explore_out_label2.py
+++ b/tools/probe/explore_out_label2.py
@@ -101,7 +101,7 @@ def probe_all_nodes():
                 except Exception as e:
                     cat_stats["instantiation_failed"] += 1
                     report["failures_instantiation"][cat_name].append(
-                        {"node": node_type_name, "reason": str(e)}
+                        {"node": node_type_name, "reason": f"{type(e).__name__}: {e}"}
                     )
                     continue
 
@@ -129,7 +129,7 @@ def probe_all_nodes():
                 except Exception as e:
                     cat_stats["io_read_failed"] += 1
                     report["failures_io_read"][cat_name].append(
-                        {"node": node_type_name, "reason": str(e)}
+                        {"node": node_type_name, "reason": f"{type(e).__name__}: {e}"}
                     )
                 finally:
                     try:

--- a/tools/probe/probe_vop_contexts.py
+++ b/tools/probe/probe_vop_contexts.py
@@ -27,7 +27,11 @@ class VopContextManager:
             logger.error(f"SOP context setup failed: {e}")
 
         try:
-            self.contexts["matnet (Shading)"] = hou.node("/mat")
+            mat_node = hou.node("/mat")
+            if mat_node is not None:
+                self.contexts["matnet (Shading)"] = mat_node
+            else:
+                logger.warning("hou.node('/mat') returned None, skipping matnet context")
         except Exception as e:
             logger.error(f"MAT context setup failed: {e}")
 
@@ -95,7 +99,7 @@ class VopContextManager:
             try:
                 root.destroy()
             except Exception:
-                pass
+                logger.debug("failed to destroy root %s", root, exc_info=True)
         self.roots.clear()
         self.contexts.clear()
 
@@ -151,15 +155,15 @@ def probe_vop_contexts():
                     break
 
                 except hou.OperationFailed:
-                    pass
+                    logger.debug("OperationFailed for '%s' in context '%s'", node_type_name, ctx_name, exc_info=True)
                 except Exception:
-                    pass
+                    logger.debug("Unexpected error for '%s' in context '%s'", node_type_name, ctx_name, exc_info=True)
                 finally:
                     if temp_node:
                         try:
                             temp_node.destroy()
                         except Exception:
-                            pass
+                            logger.debug("failed to destroy temp node '%s' in context '%s'", node_type_name, ctx_name, exc_info=True)
 
             if not success:
                 report["summary"]["failed_all"] += 1

--- a/tools/probe/probe_vop_contexts.py
+++ b/tools/probe/probe_vop_contexts.py
@@ -83,6 +83,13 @@ class VopContextManager:
         except Exception as e:
             logger.error(f"Plain VOP context setup failed: {e}")
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.cleanup()
+        return False
+
     def cleanup(self):
         for root in self.roots:
             try:
@@ -120,7 +127,7 @@ def probe_vop_contexts():
     ]
 
     try:
-        for node_type_name, node_type in cat.nodeTypes().items():
+        for node_type_name, _node_type in cat.nodeTypes().items():
             success = False
 
             for ctx_name in test_order:

--- a/tools/probe/probe_vop_contexts.py
+++ b/tools/probe/probe_vop_contexts.py
@@ -94,12 +94,12 @@ class VopContextManager:
 
 
 def probe_vop_contexts():
-    manager = VopContextManager()
-
     cat = hou.nodeTypeCategories().get("Vop")
     if not cat:
         logger.error("VOP category not found.")
         return
+
+    manager = VopContextManager()
 
     report = {
         "summary": {"total": len(cat.nodeTypes()), "success": 0, "failed_all": 0},

--- a/tools/probe/probe_vop_contexts.py
+++ b/tools/probe/probe_vop_contexts.py
@@ -1,0 +1,173 @@
+import json
+import logging
+from pathlib import Path
+import hou
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+class VopContextManager:
+    def __init__(self):
+        self.roots = []
+        self.contexts = {}
+        self._setup_contexts()
+
+    def _setup_contexts(self):
+        try:
+            geo = hou.node("/obj").createNode("geo", "temp_geo", run_init_scripts=False)
+            self.roots.append(geo)
+            self.contexts["attribvop (SOP)"] = geo.createNode(
+                "attribvop", run_init_scripts=True
+            )
+            self.contexts["volumevop (SOP)"] = geo.createNode(
+                "volumevop", run_init_scripts=True
+            )
+        except Exception as e:
+            logger.error(f"SOP context setup failed: {e}")
+
+        try:
+            self.contexts["matnet (Shading)"] = hou.node("/mat")
+        except Exception as e:
+            logger.error(f"MAT context setup failed: {e}")
+
+        try:
+            cop_net = hou.node("/obj").createNode(
+                "cop2net", "temp_cop", run_init_scripts=False
+            )
+            self.roots.append(cop_net)
+            self.contexts["vopcop2filter (COP)"] = cop_net.createNode(
+                "vopcop2filter", run_init_scripts=True
+            )
+        except Exception as e:
+            logger.error(f"COP context setup failed: {e}")
+
+        try:
+            chop_net = hou.node("/obj").createNode(
+                "chopnet", "temp_chop", run_init_scripts=False
+            )
+            self.roots.append(chop_net)
+            self.contexts["vopchop (CHOP)"] = chop_net.createNode(
+                "vopchop", run_init_scripts=True
+            )
+        except Exception as e:
+            logger.error(f"CHOP context setup failed: {e}")
+
+        try:
+            dop_net = hou.node("/obj").createNode(
+                "dopnet", "temp_dop", run_init_scripts=False
+            )
+            self.roots.append(dop_net)
+            self.contexts["popvop (DOP)"] = dop_net.createNode(
+                "popvop", run_init_scripts=True
+            )
+        except Exception as e:
+            logger.error(f"DOP context setup failed: {e}")
+
+        try:
+            stage = hou.node("/stage")
+            lop_mat = stage.createNode(
+                "materialbuilder", "temp_lop_mat", run_init_scripts=True
+            )
+            self.roots.append(lop_mat)
+            self.contexts["materialbuilder (LOP)"] = lop_mat
+        except Exception as e:
+            logger.error(f"LOP context setup failed: {e}")
+
+        try:
+            plain_vop = hou.node("/obj").createNode(
+                "vopnet", "temp_plain_vop", run_init_scripts=False
+            )
+            self.roots.append(plain_vop)
+            self.contexts["plain_vopnet"] = plain_vop
+        except Exception as e:
+            logger.error(f"Plain VOP context setup failed: {e}")
+
+    def cleanup(self):
+        for root in self.roots:
+            try:
+                root.destroy()
+            except Exception:
+                pass
+        self.roots.clear()
+        self.contexts.clear()
+
+
+def probe_vop_contexts():
+    manager = VopContextManager()
+
+    cat = hou.nodeTypeCategories().get("Vop")
+    if not cat:
+        logger.error("VOP category not found.")
+        return
+
+    report = {
+        "summary": {"total": len(cat.nodeTypes()), "success": 0, "failed_all": 0},
+        "context_wins": {ctx_name: 0 for ctx_name in manager.contexts.keys()},
+        "node_mapping": {},
+        "failed_nodes": [],
+    }
+
+    test_order = [
+        "attribvop (SOP)",
+        "matnet (Shading)",
+        "materialbuilder (LOP)",
+        "vopcop2filter (COP)",
+        "vopchop (CHOP)",
+        "popvop (DOP)",
+        "volumevop (SOP)",
+        "plain_vopnet",
+    ]
+
+    try:
+        for node_type_name, node_type in cat.nodeTypes().items():
+            success = False
+
+            for ctx_name in test_order:
+                if ctx_name not in manager.contexts:
+                    continue
+                parent = manager.contexts[ctx_name]
+
+                temp_node = None
+                try:
+                    temp_node = parent.createNode(
+                        node_type_name, run_init_scripts=False
+                    )
+
+                    if hasattr(temp_node, "outputLabels"):
+                        _ = temp_node.outputLabels()
+
+                    report["context_wins"][ctx_name] += 1
+                    report["node_mapping"][node_type_name] = ctx_name
+                    report["summary"]["success"] += 1
+                    success = True
+                    break
+
+                except hou.OperationFailed:
+                    pass
+                except Exception:
+                    pass
+                finally:
+                    if temp_node:
+                        try:
+                            temp_node.destroy()
+                        except Exception:
+                            pass
+
+            if not success:
+                report["summary"]["failed_all"] += 1
+                report["failed_nodes"].append(node_type_name)
+
+    finally:
+        manager.cleanup()
+
+    out_path = Path("vop_context_mapping.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    logger.info(f"Probe completed. Summary:\n{json.dumps(report['summary'], indent=2)}")
+    logger.info(f"Context breakdown:\n{json.dumps(report['context_wins'], indent=2)}")
+
+
+if __name__ == "__main__":
+    probe_vop_contexts()


### PR DESCRIPTION
Adds a suite of Python scripts to automate the discovery of Houdini node types, their valid instantiation contexts, and output metadata. Includes Justfile commands to run the probes and updates the dynamics example to test new VOP nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Examples**
  - Enhanced dynamics example: introduced a timestep constant and a multiply step to scale velocity before addition.

* **New Features**
  - Added multiple diagnostic probe and analysis scripts for inspecting node outputs, VOP contexts, and failure patterns.
  - Added development commands to run those probes.

* **Chores**
  - Probing tools produce JSON reports summarizing findings for offline analysis.
  - Gitignore updated to ignore generated probe report artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->