### PR TITLE
feat: support named input pins for node connections

### DIFF
--- a/crates/houdini_ramen_core/src/core/graph.rs
+++ b/crates/houdini_ramen_core/src/core/graph.rs
@@ -1,7 +1,7 @@
 use crate::core::py_escape::python_string_literal;
 use crate::core::transpiler::Transpiler;
 use crate::core::types::ParamValue;
-use crate::core::types::{ContainerType, HoudiniNode, NodeOutput, OutputPin};
+use crate::core::types::{ContainerType, HoudiniNode, InputPin, NodeOutput, OutputPin};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -70,10 +70,10 @@ impl<'a, C> InnerGraph<'a, C> {
             .push((node.get_id(), self.container_id));
     }
 
-    pub fn connect_existing<O: Into<NodeOutput>>(
+    pub fn connect_existing<I: Into<InputPin>, O: Into<NodeOutput>>(
         &mut self,
         dst: &ExistingNodeRef,
-        input_idx: usize,
+        input_pin: I,
         output: O,
     ) {
         let out = output.into();
@@ -83,7 +83,7 @@ impl<'a, C> InnerGraph<'a, C> {
             .iter_mut()
             .find(|(n, cid, _)| *cid == self.container_id && n.id == dst.id);
         if let Some((node, _, _)) = found {
-            node.inputs.insert(input_idx, (out.node_id, out.pin));
+            node.inputs.insert(input_pin.into(), (out.node_id, out.pin));
         } else {
             panic!(
                 "Houdini Ramen Error: Attempted to wire to ExistingNodeRef '{}' which does not belong to the current container.",
@@ -110,7 +110,7 @@ impl<'a, C> InnerGraph<'a, C> {
 pub struct ExistingNodeRef {
     pub id: usize,
     pub name: String,
-    pub inputs: BTreeMap<usize, (usize, OutputPin)>,
+    pub inputs: BTreeMap<InputPin, (usize, OutputPin)>,
 }
 
 impl ExistingNodeRef {
@@ -132,7 +132,7 @@ impl HoudiniNode for ExistingNodeRef {
     fn get_node_type(&self) -> &'static str {
         ""
     }
-    fn get_inputs(&self) -> &BTreeMap<usize, (usize, OutputPin)> {
+    fn get_inputs(&self) -> &BTreeMap<InputPin, (usize, OutputPin)> {
         &self.inputs
     }
     fn get_params(&self) -> &HashMap<String, ParamValue> {
@@ -164,7 +164,7 @@ impl<N> HoudiniNode for TypedExistingNodeRef<N> {
     fn get_node_type(&self) -> &'static str {
         self.base.get_node_type()
     }
-    fn get_inputs(&self) -> &BTreeMap<usize, (usize, OutputPin)> {
+    fn get_inputs(&self) -> &BTreeMap<InputPin, (usize, OutputPin)> {
         self.base.get_inputs()
     }
     fn get_params(&self) -> &HashMap<String, ParamValue> {

--- a/crates/houdini_ramen_core/src/core/transpiler/passes/links.rs
+++ b/crates/houdini_ramen_core/src/core/transpiler/passes/links.rs
@@ -1,6 +1,6 @@
 use crate::core::py_escape::python_string_literal;
 use crate::core::transpiler::builder::PythonBuilder;
-use crate::core::types::{HoudiniNode, OutputPin};
+use crate::core::types::{HoudiniNode, InputPin, OutputPin};
 use std::collections::HashMap;
 
 pub fn write_link_pass(
@@ -36,11 +36,11 @@ fn write_node_links(
         return;
     };
 
-    for (idx, (target_id, target_out_pin)) in node.get_inputs() {
+    for (in_pin, (target_id, target_out_pin)) in node.get_inputs() {
         write_single_link(
             builder,
             var_name,
-            *idx,
+            in_pin,
             *target_id,
             target_out_pin,
             id_to_var,
@@ -51,37 +51,50 @@ fn write_node_links(
 fn write_single_link(
     builder: &mut PythonBuilder,
     var_name: &str,
-    input_idx: usize,
+    input_pin: &InputPin,
     target_id: usize,
     target_out_pin: &OutputPin,
     id_to_var: &HashMap<usize, String>,
 ) {
     if let Some(target_var) = id_to_var.get(&target_id) {
-        match target_out_pin {
-            OutputPin::Index(idx) => {
+        let in_idx_expr = match input_pin {
+            InputPin::Index(idx) => idx.to_string(),
+            InputPin::Name(name) => {
+                let safe_name = python_string_literal(name);
                 builder.line(&format!(
-                    "{}.setInput({}, {}, {})",
-                    var_name, input_idx, target_var, idx
+                    "try:\n    _in_idx = {}.inputIndex({})\nexcept hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve input pin ' + repr({}) + ' on ' + {}.path())",
+                    var_name, safe_name, safe_name, var_name
                 ));
+                "_in_idx".to_string()
             }
+        };
+
+        let out_idx_expr = match target_out_pin {
+            OutputPin::Index(idx) => idx.to_string(),
             OutputPin::Name(name) => {
                 let safe_name = python_string_literal(name);
                 builder.line(&format!(
-                    "try:\n    _out_idx = {}.outputIndex({})\nexcept hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve output pin ' + repr({}) + ' on ' + {}.path())\n{}.setInput({}, {}, _out_idx)",
-                    target_var, safe_name, safe_name, target_var, var_name, input_idx, target_var
+                    "try:\n    _out_idx = {}.outputIndex({})\nexcept hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve output pin ' + repr({}) + ' on ' + {}.path())",
+                    target_var, safe_name, safe_name, target_var
                 ));
+                "_out_idx".to_string()
             }
-        }
+        };
+
+        builder.line(&format!(
+            "{}.setInput({}, {}, {})",
+            var_name, in_idx_expr, target_var, out_idx_expr
+        ));
     } else {
         emit_warning(
             builder,
             format!(
-                "WARNING: Target node with ID {} not found in the graph. Skipping connection for input {} of {}.",
-                target_id, input_idx, var_name
+                "WARNING: Target node with ID {} not found in the graph. Skipping connection for input {:?} of {}.",
+                target_id, input_pin, var_name
             ),
             format!(
-                "Target node ID {} not found. Connection to input {} skipped.",
-                target_id, input_idx
+                "Target node ID {} not found. Connection to input {:?} skipped.",
+                target_id, input_pin
             ),
         );
     }

--- a/crates/houdini_ramen_core/src/core/transpiler/passes/links.rs
+++ b/crates/houdini_ramen_core/src/core/transpiler/passes/links.rs
@@ -1,4 +1,4 @@
-use crate::core::py_escape::python_string_literal;
+use crate::core::py_escape::{python_string_literal, sanitize_py_ident};
 use crate::core::transpiler::builder::PythonBuilder;
 use crate::core::types::{HoudiniNode, InputPin, OutputPin};
 use std::collections::HashMap;
@@ -57,29 +57,8 @@ fn write_single_link(
     id_to_var: &HashMap<usize, String>,
 ) {
     if let Some(target_var) = id_to_var.get(&target_id) {
-        let in_idx_expr = match input_pin {
-            InputPin::Index(idx) => idx.to_string(),
-            InputPin::Name(name) => {
-                let safe_name = python_string_literal(name);
-                builder.line(&format!(
-                    "try:\n    _in_idx = {}.inputIndex({})\nexcept hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve input pin ' + repr({}) + ' on ' + {}.path())",
-                    var_name, safe_name, safe_name, var_name
-                ));
-                "_in_idx".to_string()
-            }
-        };
-
-        let out_idx_expr = match target_out_pin {
-            OutputPin::Index(idx) => idx.to_string(),
-            OutputPin::Name(name) => {
-                let safe_name = python_string_literal(name);
-                builder.line(&format!(
-                    "try:\n    _out_idx = {}.outputIndex({})\nexcept hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve output pin ' + repr({}) + ' on ' + {}.path())",
-                    target_var, safe_name, safe_name, target_var
-                ));
-                "_out_idx".to_string()
-            }
-        };
+        let in_idx_expr = resolve_input_pin(builder, var_name, input_pin);
+        let out_idx_expr = resolve_output_pin(builder, target_var, target_out_pin);
 
         builder.line(&format!(
             "{}.setInput({}, {}, {})",
@@ -97,6 +76,61 @@ fn write_single_link(
                 target_id, input_pin
             ),
         );
+    }
+}
+
+fn resolve_input_pin(builder: &mut PythonBuilder, var_name: &str, input_pin: &InputPin) -> String {
+    match input_pin {
+        InputPin::Index(idx) => idx.to_string(),
+        InputPin::Name(name) => {
+            let safe_name = python_string_literal(name);
+            let var = format!("_in_{}_{}", var_name, sanitize_py_ident(name));
+
+            builder.line("try:");
+            builder.indent();
+            builder.line(&format!("{} = {}.inputIndex({})", var, var_name, safe_name));
+            builder.dedent();
+            builder.line("except hou.OperationFailed:");
+            builder.indent();
+            builder.line(&format!(
+                "raise hou.OperationFailed('Could not resolve input pin ' + repr({}) + ' on ' + {}.path())",
+                safe_name, var_name
+            ));
+            builder.dedent();
+
+            var
+        }
+    }
+}
+
+fn resolve_output_pin(
+    builder: &mut PythonBuilder,
+    target_var: &str,
+    target_out_pin: &OutputPin,
+) -> String {
+    match target_out_pin {
+        OutputPin::Index(idx) => idx.to_string(),
+        OutputPin::Name(name) => {
+            let safe_name = python_string_literal(name);
+            let var = format!("_out_{}_{}", target_var, sanitize_py_ident(name));
+
+            builder.line("try:");
+            builder.indent();
+            builder.line(&format!(
+                "{} = {}.outputIndex({})",
+                var, target_var, safe_name
+            ));
+            builder.dedent();
+            builder.line("except hou.OperationFailed:");
+            builder.indent();
+            builder.line(&format!(
+                "raise hou.OperationFailed('Could not resolve output pin ' + repr({}) + ' on ' + {}.path())",
+                safe_name, target_var
+            ));
+            builder.dedent();
+
+            var
+        }
     }
 }
 

--- a/crates/houdini_ramen_core/src/core/transpiler/tests.rs
+++ b/crates/houdini_ramen_core/src/core/transpiler/tests.rs
@@ -1,7 +1,7 @@
 use super::Transpiler;
 use crate::core::graph::{ExistingNodeRef, NodeGraph};
 use crate::core::types::{
-    ContainerType, HoudiniNode, NodeOutput, OutputPin, ParamValue, SpareParam,
+    ContainerType, HoudiniNode, InputPin, NodeOutput, OutputPin, ParamValue, SpareParam,
 };
 use std::collections::{BTreeMap, HashMap};
 
@@ -10,7 +10,7 @@ struct DummyNode {
     id: usize,
     name: String,
     node_type: &'static str,
-    inputs: BTreeMap<usize, (usize, OutputPin)>,
+    inputs: BTreeMap<InputPin, (usize, OutputPin)>,
     params: HashMap<String, ParamValue>,
     spare_params: Vec<SpareParam>,
 }
@@ -25,7 +25,7 @@ impl HoudiniNode for DummyNode {
     fn get_node_type(&self) -> &'static str {
         self.node_type
     }
-    fn get_inputs(&self) -> &BTreeMap<usize, (usize, OutputPin)> {
+    fn get_inputs(&self) -> &BTreeMap<InputPin, (usize, OutputPin)> {
         &self.inputs
     }
     fn get_params(&self) -> &HashMap<String, ParamValue> {
@@ -42,7 +42,7 @@ struct DummyContainerNode {
     name: String,
     node_type: &'static str,
     dive_target: &'static str,
-    inputs: BTreeMap<usize, (usize, OutputPin)>,
+    inputs: BTreeMap<InputPin, (usize, OutputPin)>,
     params: HashMap<String, ParamValue>,
     spare_params: Vec<SpareParam>,
 }
@@ -57,7 +57,7 @@ impl HoudiniNode for DummyContainerNode {
     fn get_node_type(&self) -> &'static str {
         self.node_type
     }
-    fn get_inputs(&self) -> &BTreeMap<usize, (usize, OutputPin)> {
+    fn get_inputs(&self) -> &BTreeMap<InputPin, (usize, OutputPin)> {
         &self.inputs
     }
     fn get_params(&self) -> &HashMap<String, ParamValue> {
@@ -99,7 +99,9 @@ fn test_transpiler_script_generation() {
     node2
         .params
         .insert("color".to_string(), ParamValue::Float3([1.0, 0.5, 0.0]));
-    node2.inputs.insert(0, (101, OutputPin::Index(0)));
+    node2
+        .inputs
+        .insert(InputPin::Index(0), (101, OutputPin::Index(0)));
 
     let mut transpiler = Transpiler::new("/obj/node's_geo", None, false);
     transpiler.add_boxed(Box::new(node1)).unwrap();
@@ -131,7 +133,8 @@ fn test_missing_node_connection_warning() {
         params: HashMap::new(),
         spare_params: vec![],
     };
-    node.inputs.insert(0, (999, OutputPin::Index(0)));
+    node.inputs
+        .insert(InputPin::Index(0), (999, OutputPin::Index(0)));
 
     let mut transpiler = Transpiler::new("/obj/geo1", None, false);
     transpiler.add_boxed(Box::new(node)).unwrap();
@@ -159,7 +162,9 @@ fn test_same_name_nodes_get_distinct_python_vars() {
         params: HashMap::new(),
         spare_params: vec![],
     };
-    node2.inputs.insert(0, (1, OutputPin::Index(0)));
+    node2
+        .inputs
+        .insert(InputPin::Index(0), (1, OutputPin::Index(0)));
 
     let mut transpiler = Transpiler::new("/obj/geo1", None, false);
     transpiler.add(node1).unwrap();
@@ -428,7 +433,7 @@ fn test_transpiler_nested_subnet_creation() {
         node_type: "ray",
         inputs: {
             let mut m = BTreeMap::new();
-            m.insert(0, (502, OutputPin::Index(0)));
+            m.insert(InputPin::Index(0), (502, OutputPin::Index(0)));
             m
         },
         params: HashMap::new(),
@@ -470,7 +475,7 @@ fn test_node_graph_dive_into_api() {
             node_type: "ray",
             inputs: {
                 let mut m = BTreeMap::new();
-                m.insert(0, (prev_frame_id, OutputPin::Index(0)));
+                m.insert(InputPin::Index(0), (prev_frame_id, OutputPin::Index(0)));
                 m
             },
             params: HashMap::new(),
@@ -643,7 +648,6 @@ fn test_dive_target_parent_resolution() {
         !script.contains("parent.createNode('ray', 'child_ray')"),
         "child must not be created under root parent"
     );
-    // dive target container must get layoutChildren
     assert!(
         script.contains("n_vellum_solver_1001.node('inner_net').layoutChildren()"),
         "dive target container must get layoutChildren"
@@ -800,9 +804,10 @@ fn test_named_output_pin_wiring() {
         spare_params: vec![],
     };
 
-    node_target
-        .inputs
-        .insert(0, (3001, OutputPin::Name("force".to_string())));
+    node_target.inputs.insert(
+        InputPin::Index(0),
+        (3001, OutputPin::Name("force".to_string())),
+    );
 
     let node_source = DummyNode {
         id: 3001,
@@ -863,4 +868,41 @@ fn test_cross_container_wiring_error() {
 
         inner_b.connect_existing(&out_a, 0, &ray_b);
     });
+}
+
+#[test]
+fn test_named_input_pin_wiring() {
+    let mut transpiler = Transpiler::new("/obj/geo1", None, false);
+
+    let mut node_target = DummyNode {
+        id: 4002,
+        name: "target".to_string(),
+        node_type: "null",
+        inputs: BTreeMap::new(),
+        params: HashMap::new(),
+        spare_params: vec![],
+    };
+
+    node_target.inputs.insert(
+        InputPin::Name("pos".to_string()),
+        (4001, OutputPin::Index(0)),
+    );
+
+    let node_source = DummyNode {
+        id: 4001,
+        name: "source".to_string(),
+        node_type: "null",
+        inputs: BTreeMap::new(),
+        params: HashMap::new(),
+        spare_params: vec![],
+    };
+
+    transpiler.add_boxed(Box::new(node_source)).unwrap();
+    transpiler.add_boxed(Box::new(node_target)).unwrap();
+
+    let script = transpiler.generate_script().unwrap();
+
+    assert!(script.contains("try:\n    _in_idx = n_target_4002.inputIndex(\"pos\")"));
+    assert!(script.contains("except hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve input pin ' + repr(\"pos\") + ' on ' + n_target_4002.path())"));
+    assert!(script.contains("n_target_4002.setInput(_in_idx, n_source_4001, 0)"));
 }

--- a/crates/houdini_ramen_core/src/core/transpiler/tests.rs
+++ b/crates/houdini_ramen_core/src/core/transpiler/tests.rs
@@ -909,3 +909,47 @@ fn test_named_input_pin_wiring() {
     assert!(script.contains("except hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve input pin ' + repr(\"pos\") + ' on ' + n_target_4002.path())"));
     assert!(script.contains("n_target_4002.setInput(_in_n_target_4002_pos, n_source_4001, 0)"));
 }
+
+#[test]
+fn test_named_input_and_output_pin_wiring() {
+    let mut transpiler = Transpiler::new("/obj/geo1", None, false);
+
+    let mut node_target = DummyNode {
+        id: 5002,
+        name: "target".to_string(),
+        node_type: "null",
+        inputs: BTreeMap::new(),
+        params: HashMap::new(),
+        spare_params: vec![],
+    };
+
+    node_target.inputs.insert(
+        InputPin::Name("pos".to_string()),
+        (5001, OutputPin::Name("force".to_string())),
+    );
+
+    let node_source = DummyNode {
+        id: 5001,
+        name: "source".to_string(),
+        node_type: "null",
+        inputs: BTreeMap::new(),
+        params: HashMap::new(),
+        spare_params: vec![],
+    };
+
+    transpiler.add_boxed(Box::new(node_source)).unwrap();
+    transpiler.add_boxed(Box::new(node_target)).unwrap();
+
+    let script = transpiler.generate_script().unwrap();
+
+    assert!(script.contains("try:\n    _in_n_target_5002_pos = n_target_5002.inputIndex(\"pos\")"));
+    assert!(script.contains("except hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve input pin ' + repr(\"pos\") + ' on ' + n_target_5002.path())"));
+    assert!(
+        script
+            .contains("try:\n    _out_n_source_5001_force = n_source_5001.outputIndex(\"force\")")
+    );
+    assert!(script.contains("except hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve output pin ' + repr(\"force\") + ' on ' + n_source_5001.path())"));
+    assert!(script.contains(
+        "n_target_5002.setInput(_in_n_target_5002_pos, n_source_5001, _out_n_source_5001_force)"
+    ));
+}

--- a/crates/houdini_ramen_core/src/core/transpiler/tests.rs
+++ b/crates/houdini_ramen_core/src/core/transpiler/tests.rs
@@ -823,9 +823,12 @@ fn test_named_output_pin_wiring() {
 
     let script = transpiler.generate_script().unwrap();
 
-    assert!(script.contains("try:\n    _out_idx = n_source_3001.outputIndex(\"force\")"));
+    assert!(
+        script
+            .contains("try:\n    _out_n_source_3001_force = n_source_3001.outputIndex(\"force\")")
+    );
     assert!(script.contains("except hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve output pin ' + repr(\"force\") + ' on ' + n_source_3001.path())"));
-    assert!(script.contains("n_target_3002.setInput(0, n_source_3001, _out_idx)"));
+    assert!(script.contains("n_target_3002.setInput(0, n_source_3001, _out_n_source_3001_force)"));
 }
 
 #[test]
@@ -902,7 +905,7 @@ fn test_named_input_pin_wiring() {
 
     let script = transpiler.generate_script().unwrap();
 
-    assert!(script.contains("try:\n    _in_idx = n_target_4002.inputIndex(\"pos\")"));
+    assert!(script.contains("try:\n    _in_n_target_4002_pos = n_target_4002.inputIndex(\"pos\")"));
     assert!(script.contains("except hou.OperationFailed:\n    raise hou.OperationFailed('Could not resolve input pin ' + repr(\"pos\") + ' on ' + n_target_4002.path())"));
-    assert!(script.contains("n_target_4002.setInput(_in_idx, n_source_4001, 0)"));
+    assert!(script.contains("n_target_4002.setInput(_in_n_target_4002_pos, n_source_4001, 0)"));
 }

--- a/crates/houdini_ramen_core/src/core/types/node.rs
+++ b/crates/houdini_ramen_core/src/core/types/node.rs
@@ -2,6 +2,28 @@ use crate::core::types::param::ParamValue;
 use crate::core::types::spare::SpareParam;
 use std::collections::{BTreeMap, HashMap};
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum InputPin {
+    Index(usize),
+    Name(String),
+}
+
+impl From<usize> for InputPin {
+    fn from(idx: usize) -> Self {
+        InputPin::Index(idx)
+    }
+}
+impl From<&str> for InputPin {
+    fn from(name: &str) -> Self {
+        InputPin::Name(name.to_string())
+    }
+}
+impl From<String> for InputPin {
+    fn from(name: String) -> Self {
+        InputPin::Name(name)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutputPin {
     Index(usize),
@@ -34,7 +56,7 @@ pub trait HoudiniNode {
     fn get_id(&self) -> usize;
     fn get_name(&self) -> &str;
     fn get_node_type(&self) -> &'static str;
-    fn get_inputs(&self) -> &BTreeMap<usize, (usize, OutputPin)>;
+    fn get_inputs(&self) -> &BTreeMap<InputPin, (usize, OutputPin)>;
     fn get_params(&self) -> &HashMap<String, ParamValue>;
     fn get_spare_params(&self) -> &[SpareParam] {
         &[]

--- a/examples/004_dynamics.rs
+++ b/examples/004_dynamics.rs
@@ -6,9 +6,7 @@ use houdini_ramen::sop::{
     SopAttribvop, SopAttribvopBindclass, SopAttribvopInnerExt, SopScatter, SopSolver,
     SopSolverInnerExt, SopTestgeometryRubbertoy,
 };
-use houdini_ramen_vop::{
-    VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopMultiply,
-};
+use houdini_ramen_vop::{VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopKinefxJointangle, VopMultiply};
 
 const TIMESTEP: f32 = 1.0_f32 / 24.0_f32;
 
@@ -46,6 +44,9 @@ fn main() {
                 VopMultiply::new("multiply1")
                     .set_input(in1.out_v())
                     .set_input_at(1, &const1),
+            );
+            let dummy = vop_graph.add(VopKinefxJointangle::new("dummy")
+                .set_input_name_pt(&const1)
             );
 
             let add1 = vop_graph.add(

--- a/examples/004_dynamics.rs
+++ b/examples/004_dynamics.rs
@@ -6,7 +6,10 @@ use houdini_ramen::sop::{
     SopAttribvop, SopAttribvopBindclass, SopAttribvopInnerExt, SopScatter, SopSolver,
     SopSolverInnerExt, SopTestgeometryRubbertoy,
 };
-use houdini_ramen_vop::{VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopKinefxJointangle, VopMultiply};
+use houdini_ramen_vop::{
+    VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopKinefxJointangle,
+    VopMultiply,
+};
 
 const TIMESTEP: f32 = 1.0_f32 / 24.0_f32;
 
@@ -45,9 +48,8 @@ fn main() {
                     .set_input(in1.out_v())
                     .set_input_at(1, &const1),
             );
-            let dummy = vop_graph.add(VopKinefxJointangle::new("dummy")
-                .set_input_name_pt(&const1)
-            );
+            let _dummy =
+                vop_graph.add(VopKinefxJointangle::new("dummy").set_input_name_pt(&const1));
 
             let add1 = vop_graph.add(
                 VopAdd::new("add1")

--- a/templates/node.rs.j2
+++ b/templates/node.rs.j2
@@ -63,12 +63,16 @@ impl {{ node.struct_name }} {
     {% for inp in node.inputs %}
     pub fn set_{{ inp.safe_name }}_input<O: Into<houdini_ramen_core::types::NodeOutput>>(mut self, output: O) -> Self {
         let out = output.into();
+        {% if inp.safe_input_name %}
+        self.inputs.remove(&houdini_ramen_core::types::InputPin::Name("{{ inp.raw_input_name }}".to_string()));
+        {% endif %}
         self.inputs.insert(houdini_ramen_core::types::InputPin::Index({{ inp.index }}), (out.node_id, out.pin));
         self
     }
     {% if inp.safe_input_name %}
     pub fn set_input_name_{{ inp.safe_input_name }}<O: Into<houdini_ramen_core::types::NodeOutput>>(mut self, output: O) -> Self {
         let out = output.into();
+        self.inputs.remove(&houdini_ramen_core::types::InputPin::Index({{ inp.index }}));
         self.inputs.insert(houdini_ramen_core::types::InputPin::Name("{{ inp.raw_input_name }}".to_string()), (out.node_id, out.pin));
         self
     }

--- a/templates/node.rs.j2
+++ b/templates/node.rs.j2
@@ -12,7 +12,7 @@ pub enum {{ e.enum_name }} {
 pub struct {{ node.struct_name }} {
     pub id: usize,
     pub name: String,
-    pub inputs: std::collections::BTreeMap<usize, (usize, houdini_ramen_core::types::OutputPin)>,
+    pub inputs: std::collections::BTreeMap<houdini_ramen_core::types::InputPin, (usize, houdini_ramen_core::types::OutputPin)>,
     pub params: std::collections::HashMap<String, houdini_ramen_core::types::ParamValue>,
     pub spare_params: Vec<houdini_ramen_core::types::SpareParam>,
     {% if node.max_inputs >= 9999 %}
@@ -42,30 +42,37 @@ impl {{ node.struct_name }} {
     {% if node.max_inputs > 0 %}
     pub fn set_input_at<O: Into<houdini_ramen_core::types::NodeOutput>>(mut self, index: usize, output: O) -> Self {
         let out = output.into();
-        self.inputs.insert(index, (out.node_id, out.pin));
+        self.inputs.insert(houdini_ramen_core::types::InputPin::Index(index), (out.node_id, out.pin));
         self
     }
 
     {% if node.max_inputs >= 9999 %}
     pub fn add_input<O: Into<houdini_ramen_core::types::NodeOutput>>(mut self, output: O) -> Self {
         let out = output.into();
-        self.inputs.insert(self.next_input_index, (out.node_id, out.pin));
+        self.inputs.insert(houdini_ramen_core::types::InputPin::Index(self.next_input_index), (out.node_id, out.pin));
         self.next_input_index += 1;
         self
     }
     {% else %}
     pub fn set_input<O: Into<houdini_ramen_core::types::NodeOutput>>(mut self, output: O) -> Self {
         let out = output.into();
-        self.inputs.insert(0, (out.node_id, out.pin));
+        self.inputs.insert(houdini_ramen_core::types::InputPin::Index(0), (out.node_id, out.pin));
         self
     }
 
     {% for inp in node.inputs %}
     pub fn set_{{ inp.safe_name }}_input<O: Into<houdini_ramen_core::types::NodeOutput>>(mut self, output: O) -> Self {
         let out = output.into();
-        self.inputs.insert({{ inp.index }}, (out.node_id, out.pin));
+        self.inputs.insert(houdini_ramen_core::types::InputPin::Index({{ inp.index }}), (out.node_id, out.pin));
         self
     }
+    {% if inp.safe_input_name %}
+    pub fn set_input_name_{{ inp.safe_input_name }}<O: Into<houdini_ramen_core::types::NodeOutput>>(mut self, output: O) -> Self {
+        let out = output.into();
+        self.inputs.insert(houdini_ramen_core::types::InputPin::Name("{{ inp.raw_input_name }}".to_string()), (out.node_id, out.pin));
+        self
+    }
+    {% endif %}
     {% endfor %}
     {% endif %}
     {% endif %}
@@ -115,7 +122,7 @@ impl houdini_ramen_core::types::HoudiniNode for {{ node.struct_name }} {
     fn get_id(&self) -> usize { self.id }
     fn get_name(&self) -> &str { &self.name }
     fn get_node_type(&self) -> &'static str { "{{ node.node_type }}" }
-    fn get_inputs(&self) -> &std::collections::BTreeMap<usize, (usize, houdini_ramen_core::types::OutputPin)> { &self.inputs }
+    fn get_inputs(&self) -> &std::collections::BTreeMap<houdini_ramen_core::types::InputPin, (usize, houdini_ramen_core::types::OutputPin)> { &self.inputs }
     fn get_params(&self) -> &std::collections::HashMap<String, houdini_ramen_core::types::ParamValue> { &self.params }
     fn get_spare_params(&self) -> &[houdini_ramen_core::types::SpareParam] { &self.spare_params }
     {% if node.dive_target %}

--- a/templates/node.stub.j2
+++ b/templates/node.stub.j2
@@ -19,6 +19,9 @@ impl {{ node.struct_name }} {
     pub fn set_input<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self;
     {% for inp in node.inputs %}
     pub fn set_{{ inp.safe_name }}_input<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self;
+    {% if inp.safe_input_name %}
+    pub fn set_input_name_{{ inp.safe_input_name }}<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self;
+    {% endif %}
     {% endfor %}
     {% endif %}
     {% endif %}

--- a/tools/dump_nodes.py
+++ b/tools/dump_nodes.py
@@ -57,6 +57,7 @@ class NodeInfo:
     min_inputs: int
     max_inputs: int
     input_labels: list[str] = field(default_factory=list)
+    input_names: list[str] = field(default_factory=list)
     outputs: list[OutputInfo] = field(default_factory=list)
     parms: list[ParmInfo] = field(default_factory=list)
     builtin_inner_nodes: dict[str, str] = field(default_factory=dict)
@@ -378,6 +379,23 @@ class HoudiniNodeExtractor:
 
         return [""] * max_inputs
 
+    def _get_input_names(
+        self, temp_node: hou.Node | None, max_inputs: int
+    ) -> list[str]:
+        if max_inputs <= 0 or max_inputs >= 128:
+            return []
+
+        if temp_node and hasattr(temp_node, "inputNames"):
+            try:
+                names = list(temp_node.inputNames())
+                return names + [""] * (max_inputs - len(names))
+            except Exception as e:
+                logger.debug(
+                    f"Failed to get inputNames for '{temp_node.type().name()}': {e}"
+                )
+
+        return [""] * max_inputs
+
     def _get_outputs(
         self, temp_node: hou.Node | None, max_outputs: int
     ) -> list[OutputInfo]:
@@ -423,17 +441,19 @@ class HoudiniNodeExtractor:
 
     def _extract_io_info(
         self, node_type: hou.NodeType, cat_name: str
-    ) -> tuple[list[str], list[OutputInfo]]:
+    ) -> tuple[list[str], list[str], list[OutputInfo]]:
         max_inputs = node_type.maxNumInputs()
         max_outputs = node_type.maxNumOutputs()
 
         if max_inputs <= 0 and max_outputs <= 0:
-            return [], []
+            return [], [], []
 
         parents = self.temp_manager.get_parents(cat_name)
         if not parents:
-            return self._get_input_labels(None, max_inputs), self._get_outputs(
-                None, max_outputs
+            return (
+                self._get_input_labels(None, max_inputs),
+                self._get_input_names(None, max_inputs),
+                self._get_outputs(None, max_outputs),
             )
 
         temp_node = self._create_temp_node(
@@ -442,17 +462,19 @@ class HoudiniNodeExtractor:
 
         try:
             input_labels = self._get_input_labels(temp_node, max_inputs)
+            input_names = self._get_input_names(temp_node, max_inputs)
             outputs = self._get_outputs(temp_node, max_outputs)
         except Exception as e:
             logger.debug(
                 f"I/O extraction failed for '{cat_name}/{node_type.name()}': {e}"
             )
             input_labels = self._get_input_labels(None, max_inputs)
+            input_names = self._get_input_names(None, max_inputs)
             outputs = self._get_outputs(None, max_outputs)
         finally:
             self._destroy_temp_node(temp_node)
 
-        return input_labels, outputs
+        return input_labels, input_names, outputs
 
     def _extract_node_info(self, node_type: hou.NodeType, cat_name: str) -> NodeInfo:
         parms = []
@@ -466,12 +488,13 @@ class HoudiniNodeExtractor:
             )
 
         inner_data = self._extract_builtin_inner_nodes(node_type, cat_name)
-        input_labels, outputs = self._extract_io_info(node_type, cat_name)
+        input_labels, input_names, outputs = self._extract_io_info(node_type, cat_name)
 
         return NodeInfo(
             min_inputs=node_type.minNumInputs(),
             max_inputs=node_type.maxNumInputs(),
             input_labels=input_labels,
+            input_names=input_names,
             outputs=outputs,
             parms=parms,
             builtin_inner_nodes=inner_data.nodes,

--- a/tools/generate_rust_api.py
+++ b/tools/generate_rust_api.py
@@ -102,6 +102,8 @@ class ParsedInput:
     index: int
     doc_label: str
     safe_name: str
+    safe_input_name: str
+    raw_input_name: str
 
 
 @dataclass(frozen=True)
@@ -323,10 +325,16 @@ def parse_param(
     return parsed_param, menu_enum
 
 
-def _parse_inputs(raw_labels: list[str]) -> list[ParsedInput]:
+def _parse_inputs(raw_labels: list[str], raw_names: list[str]) -> list[ParsedInput]:
     input_resolver = SuffixResolver()
+    name_resolver = SuffixResolver()
     parsed_inputs = []
-    for idx, label in enumerate(raw_labels):
+
+    max_len = max(len(raw_labels), len(raw_names))
+    labels = raw_labels + [""] * (max_len - len(raw_labels))
+    names = raw_names + [""] * (max_len - len(raw_names))
+
+    for idx, (label, name) in enumerate(zip(labels, names, strict=True)):
         # remove line breaks and consecutive spaces to create one clean string
         clean_doc = re.sub(
             r"\s+", " ", label.replace("\n", " ").replace("\r", "")
@@ -338,8 +346,20 @@ def _parse_inputs(raw_labels: list[str]) -> list[ParsedInput]:
             safe_base = safe_base[:40].rstrip("_")
 
         safe_name = input_resolver.resolve(safe_base)
+
+        raw_input_name = name.strip()
+        safe_input_name = ""
+        if raw_input_name:
+            safe_input_name = name_resolver.resolve(snake_case(raw_input_name))
+
         parsed_inputs.append(
-            ParsedInput(index=idx, doc_label=clean_doc, safe_name=safe_name)
+            ParsedInput(
+                index=idx,
+                doc_label=clean_doc,
+                safe_name=safe_name,
+                safe_input_name=safe_input_name,
+                raw_input_name=safe_rust_string(raw_input_name),
+            )
         )
     return parsed_inputs
 
@@ -434,7 +454,9 @@ def parse_node(
         node_type=node_type,
         min_inputs=node_info.get("min_inputs", 0),
         max_inputs=node_info.get("max_inputs", 0),
-        inputs=_parse_inputs(node_info.get("input_labels", [])),
+        inputs=_parse_inputs(
+            node_info.get("input_labels", []), node_info.get("input_names", [])
+        ),
         params=params,
         enums=enums,
         output_enum=_parse_outputs(struct_name, node_info.get("outputs", [])),


### PR DESCRIPTION
Introduces an InputPin enum to allow wiring nodes by name in addition to numeric indices. The transpiler now generates Python code using hou.Node.inputIndex() to resolve these names at runtime. Updated the node dumping and API generation tools to include named input setters in the generated Rust SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for named input pins and new builder-style setters to connect inputs by name as well as by index.
  * Generated runtime now emits robust resolution logic for named inputs/outputs, including try/except resolution and explicit failure errors.

* **Refactor**
  * Unified input representation across graph, transpiler, templates, tests, and codegen to handle both numeric and named pins.

* **Tests**
  * Updated and added tests validating name-based input resolution and emitted connection code.

* **Tools**
  * Node extraction and API generator now surface per-input names for templates and codegen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->