### PR TITLE
feat: introduce typed builder API for node wiring

### DIFF
--- a/crates/houdini_ramen_core/src/core/graph.rs
+++ b/crates/houdini_ramen_core/src/core/graph.rs
@@ -250,3 +250,55 @@ impl NodeGraph {
         })
     }
 }
+
+pub struct NodeWiring<'a, 'g, C, N> {
+    inner: &'a mut InnerGraph<'g, C>,
+    target_id: usize,
+    _phantom: PhantomData<N>,
+}
+
+impl<'a, 'g, C> InnerGraph<'g, C> {
+    pub fn wire<N>(&'a mut self, target: &TypedExistingNodeRef<N>) -> NodeWiring<'a, 'g, C, N> {
+        NodeWiring {
+            inner: self,
+            target_id: target.get_id(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn wire_any(&'a mut self, target: &ExistingNodeRef) -> NodeWiring<'a, 'g, C, ()> {
+        NodeWiring {
+            inner: self,
+            target_id: target.get_id(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, 'g, C, N> NodeWiring<'a, 'g, C, N> {
+    pub fn set_input_at<O: Into<NodeOutput>>(mut self, index: usize, output: O) -> Self {
+        self.connect_internal(InputPin::Index(index), output);
+        self
+    }
+
+    pub fn set_input_name<O: Into<NodeOutput>>(mut self, name: &str, output: O) -> Self {
+        self.connect_internal(InputPin::Name(name.to_string()), output);
+        self
+    }
+
+    fn connect_internal<O: Into<NodeOutput>>(&mut self, input_pin: InputPin, output: O) {
+        let out = output.into();
+        let found = self
+            .inner
+            .graph
+            .existing_nodes
+            .iter_mut()
+            .find(|(n, cid, _)| *cid == self.inner.container_id && n.id == self.target_id);
+
+        if let Some((node, _, _)) = found {
+            node.inputs.insert(input_pin, (out.node_id, out.pin));
+        } else {
+            panic!("Houdini Ramen Error: Attempted to wire to invalid ExistingNodeRef");
+        }
+    }
+}

--- a/crates/houdini_ramen_core/src/core/graph.rs
+++ b/crates/houdini_ramen_core/src/core/graph.rs
@@ -254,6 +254,7 @@ impl NodeGraph {
 pub struct NodeWiring<'a, 'g, C, N> {
     inner: &'a mut InnerGraph<'g, C>,
     target_id: usize,
+    target_name: String,
     _phantom: PhantomData<N>,
 }
 
@@ -262,6 +263,7 @@ impl<'a, 'g, C> InnerGraph<'g, C> {
         NodeWiring {
             inner: self,
             target_id: target.get_id(),
+            target_name: target.get_name().to_string(),
             _phantom: PhantomData,
         }
     }
@@ -270,6 +272,7 @@ impl<'a, 'g, C> InnerGraph<'g, C> {
         NodeWiring {
             inner: self,
             target_id: target.get_id(),
+            target_name: target.get_name().to_string(),
             _phantom: PhantomData,
         }
     }
@@ -298,7 +301,10 @@ impl<'a, 'g, C, N> NodeWiring<'a, 'g, C, N> {
         if let Some((node, _, _)) = found {
             node.inputs.insert(input_pin, (out.node_id, out.pin));
         } else {
-            panic!("Houdini Ramen Error: Attempted to wire to invalid ExistingNodeRef");
+            panic!(
+                "Houdini Ramen Error: Attempted to wire to ExistingNodeRef '{}' which does not belong to the current container.",
+                self.target_name
+            );
         }
     }
 }

--- a/crates/houdini_ramen_core/src/core/transpiler/tests.rs
+++ b/crates/houdini_ramen_core/src/core/transpiler/tests.rs
@@ -953,3 +953,96 @@ fn test_named_input_and_output_pin_wiring() {
         "n_target_5002.setInput(_in_n_target_5002_pos, n_source_5001, _out_n_source_5001_force)"
     ));
 }
+
+#[test]
+fn test_multiple_named_pins_no_variable_collision() {
+    let mut transpiler = Transpiler::new("/obj/geo1", None, false);
+
+    let mut node_target = DummyNode {
+        id: 6002,
+        name: "target".to_string(),
+        node_type: "null",
+        inputs: BTreeMap::new(),
+        params: HashMap::new(),
+        spare_params: vec![],
+    };
+
+    node_target.inputs.insert(
+        InputPin::Name("pos".to_string()),
+        (6001, OutputPin::Name("out_pos".to_string())),
+    );
+    node_target.inputs.insert(
+        InputPin::Name("color".to_string()),
+        (6001, OutputPin::Name("out_color".to_string())),
+    );
+
+    let node_source = DummyNode {
+        id: 6001,
+        name: "source".to_string(),
+        node_type: "null",
+        inputs: BTreeMap::new(),
+        params: HashMap::new(),
+        spare_params: vec![],
+    };
+
+    transpiler.add_boxed(Box::new(node_source)).unwrap();
+    transpiler.add_boxed(Box::new(node_target)).unwrap();
+
+    let script = transpiler.generate_script().unwrap();
+
+    assert!(script.contains("_in_n_target_6002_pos = n_target_6002.inputIndex(\"pos\")"));
+    assert!(script.contains("_out_n_source_6001_out_pos = n_source_6001.outputIndex(\"out_pos\")"));
+    assert!(script.contains(
+        "n_target_6002.setInput(_in_n_target_6002_pos, n_source_6001, _out_n_source_6001_out_pos)"
+    ));
+
+    assert!(script.contains("_in_n_target_6002_color = n_target_6002.inputIndex(\"color\")"));
+    assert!(
+        script.contains("_out_n_source_6001_out_color = n_source_6001.outputIndex(\"out_color\")")
+    );
+    assert!(script.contains(
+        "n_target_6002.setInput(_in_n_target_6002_color, n_source_6001, _out_n_source_6001_out_color)"
+    ));
+}
+
+#[test]
+fn test_vex_snippet_data_escaping() {
+    let mut node = DummyNode {
+        id: 7001,
+        name: "wrangle".to_string(),
+        node_type: "attribwrangle",
+        inputs: BTreeMap::new(),
+        params: HashMap::new(),
+        spare_params: vec![],
+    };
+
+    let vex_code = "float a = 1.0;\nprintf(\"Value: %f\\n\", a);";
+    node.params.insert(
+        "snippet".to_string(),
+        ParamValue::Data(vex_code.to_string()),
+    );
+
+    let mut transpiler = Transpiler::new("/obj/geo1", None, false);
+    transpiler.add_boxed(Box::new(node)).unwrap();
+
+    let script = transpiler.generate_script().unwrap();
+
+    assert!(script.contains(
+        r#"n_wrangle_7001.parm('snippet').set("float a = 1.0;\nprintf(\"Value: %f\\n\", a);")"#
+    ));
+}
+
+#[test]
+fn test_empty_graph_generation() {
+    let transpiler = Transpiler::new("/obj/empty_geo", None, true);
+    let script = transpiler.generate_script().unwrap();
+
+    assert!(script.contains("parent_path = '/obj/empty_geo'"));
+    assert!(script.contains("parent = hou.node(parent_path)"));
+    assert!(script.contains("for child in parent.children():"));
+    assert!(script.contains("child.destroy()"));
+    assert!(script.contains("parent.layoutChildren()"));
+
+    assert!(!script.contains("createNode"));
+    assert!(!script.contains("setInput"));
+}

--- a/examples/004_dynamics.rs
+++ b/examples/004_dynamics.rs
@@ -7,8 +7,8 @@ use houdini_ramen::sop::{
     SopSolverInnerExt, SopTestgeometryRubbertoy,
 };
 use houdini_ramen_vop::{
-    VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopKinefxJointangle,
-    VopMultiply,
+    VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopGeometryvopoutput,
+    VopGeometryvopoutputWiringExt, VopMultiply,
 };
 
 const TIMESTEP: f32 = 1.0_f32 / 24.0_f32;
@@ -40,7 +40,9 @@ fn main() {
             let in1 = vop_graph
                 .geometryvopglobal1()
                 .typed_as::<VopGeometryvopglobal>();
-            let out1 = vop_graph.geometryvopoutput1();
+            let out1 = vop_graph
+                .geometryvopoutput1()
+                .typed_as::<VopGeometryvopoutput>();
 
             let const1 = vop_graph.add(VopConstant::new("timestep").with_floatdef(TIMESTEP));
             let multiply1 = vop_graph.add(
@@ -48,16 +50,13 @@ fn main() {
                     .set_input(in1.out_v())
                     .set_input_at(1, &const1),
             );
-            let _dummy =
-                vop_graph.add(VopKinefxJointangle::new("dummy").set_input_name_pt(&const1));
 
             let add1 = vop_graph.add(
                 VopAdd::new("add1")
                     .set_input(in1.out_p())
                     .set_input_at(1, &multiply1),
             );
-
-            vop_graph.connect_existing(&out1, 0, &add1);
+            vop_graph.wire(&out1).set_input_name_p(&add1);
         });
 
         inner_graph.connect_existing(&out, 0, &pointvop1);

--- a/templates/node.rs.j2
+++ b/templates/node.rs.j2
@@ -170,3 +170,26 @@ impl<'a> {{ node.struct_name }}InnerExt for houdini_ramen_core::graph::InnerGrap
     {% endfor %}
 }
 {% endif %}
+{% if node.inputs %}
+pub trait {{ node.struct_name }}WiringExt {
+    {% for inp in node.inputs %}
+    fn set_{{ inp.safe_name }}_input<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self;
+    {% if inp.safe_input_name %}
+    fn set_input_name_{{ inp.safe_input_name }}<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self;
+    {% endif %}
+    {% endfor %}
+}
+
+impl<'a, 'g, C> {{ node.struct_name }}WiringExt for houdini_ramen_core::graph::NodeWiring<'a, 'g, C, {{ node.struct_name }}> {
+    {% for inp in node.inputs %}
+    fn set_{{ inp.safe_name }}_input<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self {
+        self.set_input_at({{ inp.index }}, output)
+    }
+    {% if inp.safe_input_name %}
+    fn set_input_name_{{ inp.safe_input_name }}<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self {
+        self.set_input_name("{{ inp.raw_input_name }}", output)
+    }
+    {% endif %}
+    {% endfor %}
+}
+{% endif %}

--- a/templates/node.stub.j2
+++ b/templates/node.stub.j2
@@ -64,3 +64,13 @@ pub trait {{ node.struct_name }}InnerExt {
     {% endfor %}
 }
 {% endif %}
+{% if node.inputs %}
+pub trait {{ node.struct_name }}WiringExt {
+    {% for inp in node.inputs %}
+    fn set_{{ inp.safe_name }}_input<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self;
+    {% if inp.safe_input_name %}
+    fn set_input_name_{{ inp.safe_input_name }}<O: Into<houdini_ramen_core::types::NodeOutput>>(self, output: O) -> Self;
+    {% endif %}
+    {% endfor %}
+}
+{% endif %}


### PR DESCRIPTION
Adds a fluent `NodeWiring` API and generated `WiringExt` traits to provide a more ergonomic and type-safe way to connect node inputs. This allows wiring nodes using named or indexed setters in a builder-style pattern, replacing the more verbose manual connection methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New fluent, type-safe wiring API for connecting nodes with chainable methods to set inputs by index or name.

* **Templates**
  * Generator templates now emit node-specific wiring extension traits with convenient per-input setter methods.

* **Examples**
  * Updated example to use the new typed wiring API and remove an unused dummy node.

* **Tests**
  * Added unit tests covering named-pin wiring, parameter escaping in generated scripts, and auto-clear behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->