### PR TITLE
ci: split clippy and test into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,8 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-  test-and-lint:
-    name: Test & Lint on ${{ matrix.os }}
-    needs: fmt
+  clippy:
+    name: Clippy on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -43,6 +42,23 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run Tests
         run: cargo test --verbose --workspace


### PR DESCRIPTION
Separates linting and testing into independent, parallel jobs to improve CI efficiency and provide clearer failure reporting. This also removes the dependency on the formatting check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline structure to enhance build reliability and testing across multiple operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->