### PR TITLE
feat: use NodeOutput for display flag and graph connectivity

### DIFF
--- a/crates/houdini_ramen_core/src/core/graph.rs
+++ b/crates/houdini_ramen_core/src/core/graph.rs
@@ -64,10 +64,10 @@ impl<'a, C> InnerGraph<'a, C> {
     }
 
     /// Sets the display flag for a node inside this container.
-    pub fn set_display<T: HoudiniNode>(&mut self, node: &T) {
+    pub fn set_display<O: Into<NodeOutput>>(&mut self, output: O) {
         self.graph
             .nested_display_nodes
-            .push((node.get_id(), self.container_id));
+            .push((output.into().node_id, self.container_id));
     }
 
     pub fn connect_existing<I: Into<InputPin>, O: Into<NodeOutput>>(
@@ -197,8 +197,8 @@ impl NodeGraph {
     }
 
     /// Specify the node that will be the final output (display).
-    pub fn set_display<T: HoudiniNode>(&mut self, node: &T) {
-        self.display_node_id = Some(node.get_id());
+    pub fn set_display<O: Into<NodeOutput>>(&mut self, output: O) {
+        self.display_node_id = Some(output.into().node_id);
     }
 
     /// Registers the node in the graph and returns it to the caller as is.

--- a/crates/houdini_ramen_core/src/core/graph.rs
+++ b/crates/houdini_ramen_core/src/core/graph.rs
@@ -64,6 +64,7 @@ impl<'a, C> InnerGraph<'a, C> {
     }
 
     /// Sets the display flag for a node inside this container.
+    /// Only `output.node_id` is used; `output.pin` is ignored.
     pub fn set_display<O: Into<NodeOutput>>(&mut self, output: O) {
         self.graph
             .nested_display_nodes
@@ -197,6 +198,7 @@ impl NodeGraph {
     }
 
     /// Specify the node that will be the final output (display).
+    /// Only `output.node_id` is used; `output.pin` is ignored.
     pub fn set_display<O: Into<NodeOutput>>(&mut self, output: O) {
         self.display_node_id = Some(output.into().node_id);
     }

--- a/crates/houdini_ramen_core/src/core/types/node.rs
+++ b/crates/houdini_ramen_core/src/core/types/node.rs
@@ -75,6 +75,12 @@ impl<T: HoudiniNode> From<&T> for NodeOutput {
     }
 }
 
+impl From<&NodeOutput> for NodeOutput {
+    fn from(output: &NodeOutput) -> Self {
+        output.clone()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContainerType {
     Geo,

--- a/examples/004_dynamics.rs
+++ b/examples/004_dynamics.rs
@@ -1,12 +1,13 @@
-use houdini_ramen::core::graph::{InnerGraph, NodeGraph};
+use houdini_ramen::core::graph::NodeGraph;
 use houdini_ramen::core::live_link::send_to_houdini;
 use houdini_ramen::core::types::ContainerType::Geo;
 use houdini_ramen::sop::{
     SopAttribnoise, SopAttribnoiseAttribtype, SopAttribnoiseBasis, SopAttribnoiseOperation,
-    SopAttribvop, SopAttribvopBindclass, SopAttribvopInnerExt, SopScatter,
-    SopTestgeometryRubbertoy,
+    SopAttribvop, SopAttribvopBindclass, SopScatter, SopTestgeometryRubbertoy,
 };
-use houdini_ramen_sop::{SopSolver, SopSolverInnerExt};
+use houdini_ramen_core::graph::InnerGraph;
+use houdini_ramen_core::types::NodeOutput;
+use houdini_ramen_sop::{SopAttribvopInnerExt, SopSolver, SopSolverInnerExt};
 use houdini_ramen_vop::{
     VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopGeometryvopoutput,
     VopGeometryvopoutputWiringExt, VopMultiply,
@@ -29,22 +30,23 @@ fn main() {
 }
 
 /// Constructing the initial state (from generating the rubber toy to assigning initial velocity)
-fn build_initial_state(graph: &mut NodeGraph) -> SopAttribnoise {
+fn build_initial_state(graph: &mut NodeGraph) -> NodeOutput {
     let rubber_toy = graph.add(SopTestgeometryRubbertoy::new("rubber_toy"));
     let scatter1 = graph.add(SopScatter::new("scatter1").set_input(&rubber_toy));
 
-    graph.add(
+    let init_noise = graph.add(
         SopAttribnoise::new("init_noise")
             .set_input(&scatter1)
             .with_attribtype(SopAttribnoiseAttribtype::Vector)
             .with_attribs("v")
             .with_operation(SopAttribnoiseOperation::Set)
             .with_basis(SopAttribnoiseBasis::PerlinFlow),
-    )
+    );
+    NodeOutput::from(&init_noise)
 }
 
 /// Build a simulation loop inside the solver.
-fn build_dynamics_solver(graph: &mut NodeGraph, input_node: &SopAttribnoise) -> SopSolver {
+fn build_dynamics_solver(graph: &mut NodeGraph, input_node: impl Into<NodeOutput>) -> NodeOutput {
     let solver1 = graph.add(SopSolver::new("solver1").set_input(input_node));
 
     graph.dive_into(&solver1, |inner_graph| {
@@ -71,7 +73,7 @@ fn build_dynamics_solver(graph: &mut NodeGraph, input_node: &SopAttribnoise) -> 
         inner_graph.connect_existing(&out, 0, &pointvop1);
     });
 
-    solver1
+    NodeOutput::from(&solver1)
 }
 
 /// Build the position update logic inside VOP.

--- a/examples/004_dynamics.rs
+++ b/examples/004_dynamics.rs
@@ -1,14 +1,13 @@
-use houdini_ramen::core::graph::NodeGraph;
+use houdini_ramen::core::graph::{InnerGraph, NodeGraph};
 use houdini_ramen::core::live_link::send_to_houdini;
 use houdini_ramen::core::types::ContainerType::Geo;
+use houdini_ramen::core::types::NodeOutput;
 use houdini_ramen::sop::{
     SopAttribnoise, SopAttribnoiseAttribtype, SopAttribnoiseBasis, SopAttribnoiseOperation,
-    SopAttribvop, SopAttribvopBindclass, SopScatter, SopTestgeometryRubbertoy,
+    SopAttribvop, SopAttribvopBindclass, SopAttribvopInnerExt, SopScatter, SopSolver,
+    SopSolverInnerExt, SopTestgeometryRubbertoy,
 };
-use houdini_ramen_core::graph::InnerGraph;
-use houdini_ramen_core::types::NodeOutput;
-use houdini_ramen_sop::{SopAttribvopInnerExt, SopSolver, SopSolverInnerExt};
-use houdini_ramen_vop::{
+use houdini_ramen::vop::{
     VopAdd, VopConstant, VopGeometryvopglobal, VopGeometryvopglobalOutputs, VopGeometryvopoutput,
     VopGeometryvopoutputWiringExt, VopMultiply,
 };


### PR DESCRIPTION
Refactor the `set_display` methods in `NodeGraph` and `InnerGraph` to accept any type implementing `Into` rather than requiring a specific node reference. This provides more flexibility when defining output nodes and allows example code to use `NodeOutput` as a common interface for passing nodes between functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved flexibility of node output handling and display selection to accept generic outputs for more consistent display configuration.
* **Examples**
  * Updated the dynamics example to use a unified node output representation throughout, simplifying how nodes are created and passed between steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->